### PR TITLE
Fix – Broken Video Links in Module 4 (DevOps Fundamentals) 

### DIFF
--- a/source/advanced-introduction-to-devops/source/devops-lessons-preparation.md
+++ b/source/advanced-introduction-to-devops/source/devops-lessons-preparation.md
@@ -356,7 +356,7 @@
 
   - [GitHub Insights Webpage](https://docs.github.com/en/enterprise-cloud@latest/organizations/collaborating-with-groups-in-organizations/viewing-insights-for-your-organization)
 
-  - [GitHub Insights Video](https://www.youtube.com/watch?v=wq1LGr2j1Fw)
+  - [GitHub Insights Video](https://www.youtube.com/watch?v=HwYLw2M0Q_k)
 
 - Gitlab
 


### PR DESCRIPTION
### Summary

This PR fixes broken video links in Module 4 of the DevOps Fundamentals section, specifically those related to the GitHub project and GitHub Insights. 

### Changes Made

- Updated 2 outdated video URLs in `devops-lessons-preparation.md`

### Changes Insights

I included the two most relevant videos for the mentioned section. However, they do not fully cover all the topics; even other videos from the channel do not cover it entirely, for example, [1](https://www.youtube.com/watch?v=Iq6uHf6oBhM), [2](https://www.youtube.com/watch?v=yFQ-p6wMS_Y), and [3](https://www.youtube.com/watch?v=D80u__nYYWw). I highly recommend using the videos from the community free GitHub course instead, if these do not go against the repo rules and the course roles, as the demos in that session provide more complete and accurate coverage of the required content.

### Related Issue

Fixes #817
